### PR TITLE
Don't show datastream on visualize data table if user doesn't have read permissions

### DIFF
--- a/src/store/dataVisualization.ts
+++ b/src/store/dataVisualization.ts
@@ -94,10 +94,21 @@ export const useDataVisStore = defineStore('dataVisualization', () => {
     )
   }
 
+  /** Filter out this datastream if the data is marked private and the current user
+   * is not an owner of the associated site
+   */
+  function hasObservationsReadPermission(datastream: Datastream) {
+    if (datastream.isDataVisible) return true
+
+    const matchingThing = things.value.find((t) => t.id === datastream.thingId)
+    return matchingThing?.ownsThing
+  }
+
   const filteredDatastreams = computed(() => {
     return datastreams.value.filter(
       (datastream) =>
         matchesSelectedThing(datastream) &&
+        hasObservationsReadPermission(datastream) &&
         matchesSelectedObservedProperty(datastream) &&
         matchesSelectedProcessingLevel(datastream)
     )


### PR DESCRIPTION
Resolves hydroserver2/hydroserver#203

This PR updates the 'Visualize Data' table filtering to hide any datastream the user doesn't have observations read permissions for.

The frontend was showing a datastream in the list of plottable datasets for the 'visualize data' page even if isDataVisible was false. This is the correct behavior for the Site Details page, but doesn't make sense for this page since the user won't be able to plot anything since they're restricted from accessing the data. 

