### PR TITLE
Echarts - YAxis >=1e6 labels are now in scientific notation

### DIFF
--- a/src/utils/plotting/echarts.ts
+++ b/src/utils/plotting/echarts.ts
@@ -39,6 +39,12 @@ export function createYAxisConfigurations(
   return yAxisConfigurations
 }
 
+export function yAxisFormatter(value: number) {
+  return Math.abs(value) >= 1e6
+    ? value.toExponential(1)
+    : value.toLocaleString()
+}
+
 export function generateYAxisOptions(
   yAxisConfigurations: yAxisConfigurationMap
 ): YAXisComponentOption[] {
@@ -61,6 +67,7 @@ export function generateYAxisOptions(
       axisLabel: {
         showMaxLabel: false,
         showMinLabel: false,
+        formatter: yAxisFormatter,
       },
       axisTick: {
         show: true,


### PR DESCRIPTION
Resolves hydroserver2/hydroserver#198

Made it so numbers bigger than abs(1e6) are put in scientific notation with one decimal point. Tested on numbers in the 1, 100,000, 1 million and 100 million ranges.

![image](https://github.com/user-attachments/assets/00ca48fe-e88a-4f83-8585-266bbf1cb08b)
