### PR TITLE
Rename emit('created') to 'site-created'

### DIFF
--- a/src/components/Site/SiteForm.vue
+++ b/src/components/Site/SiteForm.vue
@@ -202,7 +202,7 @@ const { updatePhotos } = usePhotosStore()
 const { updateTags } = useTagStore()
 
 const props = defineProps({ thingId: String })
-const emit = defineEmits(['close', 'created'])
+const emit = defineEmits(['close', 'site-created'])
 let loaded = ref(false)
 const valid = ref(false)
 const myForm = ref<VForm>()
@@ -239,8 +239,6 @@ function closeDialog() {
 async function uploadThing() {
   await myForm.value?.validate()
   if (!valid.value) return
-  emit('close')
-  if (!thing) return
   if (!includeDataDisclaimer.value) thing.dataDisclaimer = ''
 
   try {
@@ -248,7 +246,10 @@ async function uploadThing() {
       ? await api.updateThing(thing)
       : await api.createThing(thing)
 
-    if (!props.thingId) emit('created')
+    if (!props.thingId) {
+      console.log('emitting site-created from SiteForm.vue')
+      emit('site-created')
+    }
 
     console.log('Site upload response', storedThing.value)
     // Set the tag context to the current site so updateTags can compare
@@ -258,6 +259,8 @@ async function uploadThing() {
     await updatePhotos(storedThing.value!.id)
   } catch (error) {
     console.error('Error updating thing', error)
+  } finally {
+    emit('close')
   }
 }
 

--- a/src/pages/Sites.vue
+++ b/src/pages/Sites.vue
@@ -112,7 +112,7 @@
   </div>
 
   <v-dialog v-model="showSiteForm" width="60rem">
-    <SiteForm @close="showSiteForm = false" @created="loadThings" />
+    <SiteForm @close="showSiteForm = false" @site-created="loadThings" />
   </v-dialog>
 </template>
 


### PR DESCRIPTION
hydroserver2/hydroserver#219

I think the problem is likely a naming conflict with Vue's lifecycle hooks. 'Created' is a lifecycle hook, so I'm thinking having an event emit with the same name is causing unexpected behavior. The 'loadData()' function in the Sites.vue parent component never gets called despite the child component emiting 'created'. This change renames the emited event to 'site-created'. 