### PR TITLE
Load the datastream table metadata in the context of its workspace

### DIFF
--- a/src/components/Datastream/DatastreamTable.vue
+++ b/src/components/Datastream/DatastreamTable.vue
@@ -275,7 +275,7 @@ const { item, items, openEdit, openDelete, openDialog, onUpdate, onDelete } =
   )
 
 const { sensors, units, observedProperties, processingLevels, fetchMetadata } =
-  useMetadata()
+  useMetadata(toRef(props, 'workspace'))
 
 const visibleDatastreams = computed(() => {
   return items.value


### PR DESCRIPTION
Fixes guests not being able to see the datastream table metadata on the site details page