### PR TITLE
297 datastream presentation

### DIFF
--- a/src/components/Datastream/DatastreamInformationPanels.vue
+++ b/src/components/Datastream/DatastreamInformationPanels.vue
@@ -1,0 +1,256 @@
+<template>
+  <v-expansion-panels
+    v-model="expandedPanels"
+    multiple
+    variant="inset"
+    color="grey-lighten-4"
+    elevation="0"
+    class="bg-grey"
+  >
+    <v-expansion-panel
+      title="General"
+      :class="{ 'mt-4': expandedPanels.includes(0) }"
+      :rounded="expandedPanels.includes(0) ? 'md' : 0"
+    >
+      <v-expansion-panel-text>
+        <v-list dense>
+          <v-list-item v-for="(item, index) in generalItems" :key="index">
+            <strong>{{ item.label }}</strong
+            >: {{ item.value }}
+          </v-list-item>
+        </v-list>
+      </v-expansion-panel-text>
+    </v-expansion-panel>
+
+    <v-expansion-panel title="Site & location">
+      <v-expansion-panel-text>
+        <v-list dense>
+          <v-list-item v-for="(item, index) in locationItems" :key="index">
+            <strong>{{ item.label }}</strong
+            >: {{ item.value }}
+          </v-list-item>
+        </v-list>
+      </v-expansion-panel-text>
+    </v-expansion-panel>
+
+    <v-expansion-panel title="Sensor">
+      <v-expansion-panel-text>
+        <v-list dense>
+          <v-list-item v-for="(item, index) in sensorItems" :key="index">
+            <strong>{{ item.label }}</strong
+            >: {{ item.value }}
+          </v-list-item>
+        </v-list>
+      </v-expansion-panel-text>
+    </v-expansion-panel>
+
+    <v-expansion-panel title="Observed Property">
+      <v-expansion-panel-text>
+        <v-list dense>
+          <v-list-item
+            v-for="(item, index) in observedPropertyItems"
+            :key="index"
+          >
+            <strong>{{ item.label }}</strong
+            >: {{ item.value }}
+          </v-list-item>
+        </v-list>
+      </v-expansion-panel-text>
+    </v-expansion-panel>
+
+    <v-expansion-panel title="Unit">
+      <v-expansion-panel-text>
+        <v-list dense>
+          <v-list-item v-for="(item, index) in unitItems" :key="index">
+            <strong>{{ item.label }}</strong
+            >: {{ item.value }}
+          </v-list-item>
+        </v-list>
+      </v-expansion-panel-text>
+    </v-expansion-panel>
+
+    <v-expansion-panel
+      title="Processing Level"
+      :class="{ 'mb-4': expandedPanels.includes(5) }"
+      :rounded="expandedPanels.includes(5) ? 'md' : 0"
+    >
+      <v-expansion-panel-text>
+        <v-list dense>
+          <v-list-item
+            v-for="(item, index) in processingLevelItems"
+            :key="index"
+          >
+            <strong>{{ item.label }}</strong
+            >: {{ item.value }}
+          </v-list-item>
+        </v-list>
+      </v-expansion-panel-text>
+    </v-expansion-panel>
+  </v-expansion-panels>
+</template>
+
+<script setup lang="ts">
+import { api } from '@/services/api'
+import { useDataVisStore } from '@/store/dataVisualization'
+import { Datastream, Sensor, Unit } from '@/types'
+import { storeToRefs } from 'pinia'
+import { computed, onMounted, ref } from 'vue'
+
+const props = defineProps({
+  datastream: { type: Object as () => Datastream, required: true },
+})
+
+const unit = ref<Unit | null>(null)
+const sensor = ref<Sensor | null>(null)
+const expandedPanels = ref<number[]>([])
+
+const { processingLevels, observedProperties, things, plottedDatastreams } =
+  storeToRefs(useDataVisStore())
+
+const matchingThing = computed(() => {
+  return things.value.find((t) => t.id === props.datastream.thingId)
+})
+
+const generalItems = computed(() => [
+  { label: 'Datastream name', value: props.datastream.name },
+  { label: 'Description', value: props.datastream.description },
+  { label: 'Number Of Observations', value: props.datastream.valueCount },
+  { label: 'Date Last Updated', value: props.datastream.phenomenonEndTime },
+  { label: 'Begin Date', value: props.datastream.phenomenonBeginTime },
+  { label: 'End Date', value: props.datastream.phenomenonEndTime },
+  { label: 'Data Type', value: props.datastream.observationType },
+  { label: 'Value Type', value: props.datastream.resultType },
+  { label: 'Sample Medium', value: props.datastream.sampledMedium },
+  { label: 'Nodata value', value: props.datastream.noDataValue },
+  { label: 'Id', value: props.datastream.id },
+  { label: 'Workspace Id', value: props.datastream.workspaceId },
+  {
+    label: 'Aggregation Statistic',
+    value: props.datastream.aggregationStatistic,
+  },
+  {
+    label: 'Intended Time Spacing',
+    value: props.datastream.intendedTimeSpacing,
+  },
+  {
+    label: 'Intended Time Spacing Unit',
+    value: props.datastream.intendedTimeSpacingUnit,
+  },
+  {
+    label: 'Time Aggregation Interval',
+    value: props.datastream.timeAggregationInterval,
+  },
+  {
+    label: 'Time Aggregation Interval Unit',
+    value: props.datastream.timeAggregationIntervalUnit,
+  },
+  { label: 'Is Private', value: props.datastream.isPrivate ? 'Yes' : 'No' },
+  { label: 'Is Visible', value: props.datastream.isVisible ? 'Yes' : 'No' },
+
+  { label: 'Datasource Id', value: props.datastream.dataSourceId },
+])
+
+const locationItems = computed(() => {
+  if (!matchingThing.value) return []
+
+  const {
+    name,
+    samplingFeatureCode,
+    siteType,
+    latitude,
+    longitude,
+    state,
+    county,
+    country,
+    elevation_m,
+    elevationDatum,
+    description,
+    samplingFeatureType,
+    isPrivate,
+    workspaceId,
+    id,
+  } = matchingThing.value
+  return [
+    { label: 'Site name', value: name },
+    { label: 'Site code', value: samplingFeatureCode },
+    { label: 'Description', value: description },
+    { label: 'Site type', value: siteType },
+    { label: 'Latitude', value: latitude },
+    { label: 'Longitude', value: longitude },
+    { label: 'Elevation (m)', value: elevation_m },
+    { label: 'Elevation datum', value: elevationDatum },
+    { label: 'State/Province/Region', value: state },
+    { label: 'County/District', value: county },
+    { label: 'Country', value: country },
+
+    { label: 'Sampling feature type', value: samplingFeatureType },
+    { label: 'Is private', value: isPrivate ? 'Yes' : 'No' },
+    { label: 'Thing id', value: id },
+  ]
+})
+
+const observedPropertyItems = computed(() => {
+  if (!props.datastream.observedPropertyId) return []
+
+  const op = observedProperties.value.find(
+    (op) => op.id === props.datastream.observedPropertyId
+  )
+  return op
+    ? [
+        { label: 'Name', value: op.name },
+        { label: 'Definition', value: op.definition },
+        { label: 'Description', value: op.description },
+        { label: 'Type', value: op.type },
+        { label: 'Code', value: op.code },
+      ]
+    : []
+})
+
+const unitItems = computed(() => {
+  return unit.value
+    ? [
+        { label: 'Name', value: unit.value.name },
+        { label: 'Symbol', value: unit.value.symbol },
+        { label: 'Definition', value: unit.value.definition },
+        { label: 'Type', value: unit.value.type },
+      ]
+    : []
+})
+
+const sensorItems = computed(() => {
+  return sensor.value
+    ? [
+        { label: 'Name', value: sensor.value.name },
+        { label: 'Description', value: sensor.value.description },
+        { label: 'Manufacturer', value: sensor.value.manufacturer },
+        { label: 'Model', value: sensor.value.model },
+        { label: 'Method Type', value: sensor.value.methodType },
+        { label: 'Method Code', value: sensor.value.methodCode },
+        { label: 'Method Link', value: sensor.value.methodLink },
+        { label: 'Encoding Type', value: sensor.value.encodingType },
+        { label: 'Model Link', value: sensor.value.modelLink },
+      ]
+    : []
+})
+const processingLevelItems = computed(() => {
+  const pl = processingLevels.value.find(
+    (pl) => pl.id === props.datastream.processingLevelId
+  )
+  return pl
+    ? [
+        { label: 'Code', value: pl.code },
+        { label: 'Definition', value: pl.definition },
+        { label: 'Explanation', value: pl.explanation },
+      ]
+    : []
+})
+
+onMounted(async () => {
+  const [unitResult, sensorResult] = await Promise.all([
+    api.getUnit(props.datastream.unitId),
+    api.fetchSensor(props.datastream.sensorId),
+  ])
+  unit.value = unitResult
+  sensor.value = sensorResult
+})
+</script>

--- a/src/components/Datastream/DatastreamTable.vue
+++ b/src/components/Datastream/DatastreamTable.vue
@@ -272,9 +272,14 @@
     />
   </v-dialog>
 
-  <v-dialog v-model="openInfoCard" width="50rem" v-if="selectedDatastream">
+  <v-dialog
+    v-model="openInfoCard"
+    width="50rem"
+    v-if="selectedDatastream && thing"
+  >
     <DatastreamTableInfoCard
       :datastream="selectedDatastream"
+      :thing="thing"
       @close="openInfoCard = false"
     />
   </v-dialog>

--- a/src/components/Datastream/DatastreamTable.vue
+++ b/src/components/Datastream/DatastreamTable.vue
@@ -1,194 +1,251 @@
 <template>
   <h5 class="text-h5 my-6">Datastreams available at this site</h5>
 
-  <v-row class="pb-4">
-    <v-col cols="auto" v-if="canCreateDatastreams">
-      <v-btn-secondary prependIcon="mdi-plus" @click="openCreate = true"
-        >Add new datastream</v-btn-secondary
-      >
-    </v-col>
-    <v-col>
-      <v-btn
-        color="blue-grey-lighten-2"
-        prependIcon="mdi-chart-line"
-        variant="elevated"
-        :to="{ name: 'VisualizeData', query: { sites: thing!.id } }"
-        >View on Data Visualization Page</v-btn
-      >
-    </v-col>
-  </v-row>
-
   <h6 class="text-h6" style="color: #b71c1c">
     {{ thing!.dataDisclaimer }}
   </h6>
 
-  <v-data-table-virtual
-    class="elevation-3 my-4"
-    :headers="headers"
-    :items="visibleDatastreams"
-    :sort-by="sortBy"
-    :style="{ 'max-height': `100vh` }"
-    fixed-header
-  >
-    <template v-slot:item.info="{ item }">
-      <v-col>
-        <v-row style="font-size: 1.2em">
-          <strong class="mr-2">Observed Property:</strong>
+  <v-card>
+    <v-toolbar color="secondary">
+      <v-text-field
+        class="mx-4"
+        clearable
+        v-model="search"
+        prepend-inner-icon="mdi-magnify"
+        label="Search"
+        hide-details
+        density="compact"
+        variant="underlined"
+        rounded="xl"
+        maxWidth="300"
+      />
+      <v-spacer />
+      <v-btn
+        color="white"
+        variant="outlined"
+        prependIcon="mdi-chart-line"
+        class="mr-2"
+        :to="{ name: 'VisualizeData', query: { sites: thing!.id } }"
+        >View on Data Visualization Page</v-btn
+      >
+      <v-btn-add
+        v-if="canCreateDatastreams"
+        color="white"
+        prependIcon="mdi-plus"
+        @click="openCreate = true"
+        class="mr-2"
+        >Add new datastream</v-btn-add
+      >
+    </v-toolbar>
+
+    <v-data-table-virtual
+      :headers="headers"
+      :items="visibleDatastreams"
+      :search="search"
+      :sort-by="sortBy"
+      :style="{ 'max-height': `100vh` }"
+      fixed-header
+    >
+      <template
+        v-slot:item.info="{ item, internalItem, isExpanded, toggleExpand }"
+      >
+        <p style="font-size: 1.2em" class="mt-2">
+          <strong class="mr-2">Observed property:</strong>
           <strong>{{ item.OPName }}</strong>
-        </v-row>
-        <v-row> <strong class="mr-2">Identifier:</strong> {{ item.id }} </v-row>
-        <v-row>
-          <strong class="mr-2">Processing Level:</strong>
-          {{
-            processingLevels.find((p) => p.id === item.processingLevelId)?.code
-          }}
-        </v-row>
-        <v-row>
-          <strong class="mr-2">Sampled Medium:</strong>
+        </p>
+        <p><strong class="mr-2">Identifier:</strong> {{ item.id }}</p>
+        <p>
+          <strong class="mr-2">Processing level:</strong>
+          {{ item.processingLevelName }}
+        </p>
+        <!-- <template v-if="isExpanded(internalItem)"> -->
+        <p>
+          <strong class="mr-2">Sampled medium:</strong>
           {{ item.sampledMedium }}
-        </v-row>
-        <v-row>
+        </p>
+        <p>
           <strong class="mr-2">Sensor:</strong>
           {{ sensors.find((s) => s.id === item.sensorId)?.name }}
-        </v-row>
-      </v-col>
-    </template>
+        </p>
+        <p>
+          <strong class="mr-2">No data value:</strong> {{ item.noDataValue }}
+        </p>
+        <p class="mb-2">
+          <strong class="mr-2">Aggregation statistic:</strong>
+          {{ item.aggregationStatistic }}
+        </p>
+        <!-- </template> -->
+        <!-- <v-btn
+          class="pl-0"
+          color="medium-emphasis"
+          size="small"
+          variant="text"
+          :append-icon="
+            isExpanded(internalItem) ? 'mdi-chevron-up' : 'mdi-chevron-down'
+          "
+          @click.stop="toggleExpand(internalItem)"
+        >
+          {{ isExpanded(internalItem) ? '... Show less' : '... Show more' }}
+        </v-btn> -->
+      </template>
 
-    <template v-slot:item.observations="{ item }">
-      <div v-if="!canViewDatastreams && !item.isVisible">
-        Data is private for this datastream
-      </div>
-      <div v-else>
+      <template v-slot:item.time="{ item }">
+        <p class="mt-2">
+          <strong class="mr-2">Begin date:</strong>
+          {{
+            item.phenomenonBeginTime ? formatTime(item.phenomenonBeginTime) : ''
+          }}
+        </p>
+        <p>
+          <strong class="mr-2">End date:</strong>
+          {{ item.phenomenonEndTime ? formatTime(item.phenomenonEndTime) : '' }}
+        </p>
+        <p>
+          <strong class="mr-2">Time aggregation interval:</strong>
+          {{ item.timeAggregationInterval }}
+          {{ item.timeAggregationIntervalUnit }}
+        </p>
+        <p>
+          <strong class="mr-2">Intended time spacing:</strong>
+          {{ item.intendedTimeSpacing }}
+          {{ item.intendedTimeSpacingUnit }}
+        </p>
+        <p>
+          <strong class="mr-2">Status:</strong>
+          {{ item.status }}
+        </p>
+        <p>
+          <strong class="mr-2">Value count:</strong>
+          {{ item.valueCount }}
+        </p>
+      </template>
+
+      <template v-slot:item.observations="{ item }">
+        <div v-if="!canViewDatastreams && !item.isVisible" class="mt-2">
+          Data is private for this datastream
+        </div>
+        <Sparkline
+          v-else
+          class="mt-2"
+          :datastream="item"
+          @open-chart="item.chartOpen = true"
+          :unitName="item.unitName"
+        />
+
         <v-dialog v-model="item.chartOpen" width="80rem">
           <DatastreamPopupPlot
             :datastream="item"
             @close="item.chartOpen = false"
           />
         </v-dialog>
-        <Sparkline :datastream="item" @open-chart="item.chartOpen = true" />
-      </div>
-    </template>
+      </template>
 
-    <template v-slot:item.last_observation="{ item }">
-      <div
-        v-if="
-          (canViewDatastreams || item.isVisible) &&
-          observations[item.id]?.dataArray?.length
-        "
-      >
-        <v-row>
-          {{ getMostRecentObsTime(observations[item.id].dataArray) }}
-        </v-row>
-        <v-row>
-          {{ getMostRecentObsVal(observations[item.id].dataArray) }}&nbsp;
-          {{ units.find((u) => u.id === item.unitId)?.name }}
-        </v-row>
-      </div>
-    </template>
+      <template v-slot:item.actions="{ item }">
+        <v-row align="center" style="height: 90%" class="mt-2">
+          <v-tooltip bottom :openDelay="500" v-if="canEditDatastreams">
+            <template v-slot:activator="{ props }">
+              <v-icon
+                :icon="
+                  item.isVisible ? 'mdi-file-eye-outline' : 'mdi-file-remove'
+                "
+                :color="item.isVisible ? 'grey' : 'grey-lighten-1'"
+                small
+                v-bind="props"
+                @click="toggleDataVisibility(item)"
+              />
+            </template>
+            <span v-if="item.isVisible"
+              >Hide the data for this datastream from guests of your site while
+              keeping the metadata public. Owners will still see it
+            </span>
+            <span v-else
+              >Make the data for this datastream publicly visible</span
+            >
+          </v-tooltip>
 
-    <template v-slot:item.actions="{ item }">
-      <v-row>
-        <v-tooltip bottom :openDelay="500" v-if="canEditDatastreams">
-          <template v-slot:activator="{ props }">
-            <v-icon
-              :icon="
-                item.isVisible ? 'mdi-file-eye-outline' : 'mdi-file-remove'
-              "
-              :color="item.isVisible ? 'grey' : 'grey-lighten-1'"
-              small
-              v-bind="props"
-              @click="toggleDataVisibility(item)"
-            />
-          </template>
-          <span v-if="item.isVisible"
-            >Hide the data for this datastream from guests of your site while
-            keeping the metadata public. Owners will still see it
-          </span>
-          <span v-else>Make the data for this datastream publicly visible</span>
-        </v-tooltip>
+          <v-tooltip bottom :openDelay="500" v-if="canEditDatastreams">
+            <template v-slot:activator="{ props }">
+              <v-icon
+                :icon="item.isPrivate ? 'mdi-eye-off' : 'mdi-eye'"
+                :color="item.isPrivate ? 'grey-lighten-1' : 'grey'"
+                small
+                v-bind="props"
+                @click="toggleVisibility(item)"
+              />
+            </template>
+            <span v-if="item.isPrivate"
+              >Hide this datastream from guests of your site. Owners will still
+              see it</span
+            >
+            <span v-else>Make this datastream publicly visible</span>
+          </v-tooltip>
 
-        <v-tooltip bottom :openDelay="500" v-if="canEditDatastreams">
-          <template v-slot:activator="{ props }">
-            <v-icon
-              :icon="item.isPrivate ? 'mdi-eye-off' : 'mdi-eye'"
-              :color="item.isPrivate ? 'grey-lighten-1' : 'grey'"
-              small
-              v-bind="props"
-              @click="toggleVisibility(item)"
-            />
-          </template>
-          <span v-if="item.isPrivate"
-            >Hide this datastream from guests of your site. Owners will still
-            see it</span
+          <v-tooltip
+            v-if="!canViewDatastreams && !item.isVisible"
+            bottom
+            :openDelay="100"
           >
-          <span v-else>Make this datastream publicly visible</span>
-        </v-tooltip>
+            <template v-slot:activator="{ props }">
+              <v-icon v-bind="props" icon="mdi-lock" />
+            </template>
+            <span>The data for this datastream is private </span>
+          </v-tooltip>
 
-        <v-tooltip
-          v-if="!canViewDatastreams && !item.isVisible"
-          bottom
-          :openDelay="100"
-        >
-          <template v-slot:activator="{ props }">
-            <v-icon v-bind="props" icon="mdi-lock" />
-          </template>
-          <span>The data for this datastream is private </span>
-        </v-tooltip>
-
-        <v-menu v-else>
-          <template v-slot:activator="{ props }">
-            <v-icon v-bind="props" icon="mdi-dots-vertical" />
-          </template>
-          <v-list>
-            <!-- <div v-if="canEditDatastreams"> -->
-            <!-- <v-list-item
+          <v-menu v-else>
+            <template v-slot:activator="{ props }">
+              <v-icon v-bind="props" icon="mdi-dots-vertical" />
+            </template>
+            <v-list>
+              <!-- <div v-if="canEditDatastreams"> -->
+              <!-- <v-list-item
                 prepend-icon="mdi-link-variant"
                 title="Link Data Source"
                 @click="openLinker = true"
               /> -->
-            <v-list-item
-              v-if="canEditDatastreams"
-              prepend-icon="mdi-pencil"
-              title="Edit Datastream Metadata"
-              @click="openDialog(item, 'edit')"
-            />
-            <!-- </div> -->
-            <div v-if="canDeleteDatastreams">
               <v-list-item
-                prepend-icon="mdi-delete"
-                title="Delete Datastream"
-                @click="openDialog(item, 'delete')"
+                v-if="canEditDatastreams"
+                prepend-icon="mdi-pencil"
+                title="Edit Datastream Metadata"
+                @click="openDialog(item, 'edit')"
               />
-            </div>
-            <v-list-item
-              prepend-icon="mdi-chart-line"
-              title="Visualize Data"
-              :to="{
-                name: 'VisualizeData',
-                query: { sites: item.thingId, datastreams: item.id },
-              }"
+              <!-- </div> -->
+              <div v-if="canDeleteDatastreams">
+                <v-list-item
+                  prepend-icon="mdi-delete"
+                  title="Delete Datastream"
+                  @click="openDialog(item, 'delete')"
+                />
+              </div>
+              <v-list-item
+                prepend-icon="mdi-chart-line"
+                title="Visualize Data"
+                :to="{
+                  name: 'VisualizeData',
+                  query: { sites: item.thingId, datastreams: item.id },
+                }"
+              />
+              <v-list-item
+                prepend-icon="mdi-download"
+                title="Download Data"
+                @click="onDownload(item.id)"
+              />
+            </v-list>
+          </v-menu>
+        </v-row>
+        <v-row v-if="downloading[item.id]">
+          <v-col class="px-0">
+            <v-progress-circular
+              indeterminate
+              size="16"
+              width="2"
+              color="primary"
             />
-            <v-list-item
-              prepend-icon="mdi-download"
-              title="Download Data"
-              @click="onDownload(item.id)"
-            />
-          </v-list>
-        </v-menu>
-      </v-row>
-      <v-row v-if="downloading[item.id]">
-        <v-col class="px-0">
-          <v-progress-circular
-            indeterminate
-            size="16"
-            width="2"
-            color="primary"
-          />
-          preparing file...
-        </v-col>
-      </v-row>
-    </template>
-  </v-data-table-virtual>
+            preparing file...
+          </v-col>
+        </v-row>
+      </template>
+    </v-data-table-virtual>
+  </v-card>
 
   <v-dialog v-model="openCreate" width="80rem">
     <DatastreamForm
@@ -234,6 +291,7 @@ import { useWorkspacePermissions } from '@/composables/useWorkspacePermissions'
 import { useTableLogic } from '@/composables/useTableLogic'
 import { downloadDatastreamCSV } from '@/utils/CSVDownloadUtils'
 import { Snackbar } from '@/utils/notifications'
+import { formatTime } from '@/utils/time'
 
 const props = defineProps({
   workspace: { type: Object as () => Workspace, required: true },
@@ -245,6 +303,7 @@ const openCreate = ref(false)
 const workspaceRef = toRef(props, 'workspace')
 const thingIdRef = computed(() => thing.value!.id)
 const downloading = reactive<Record<string, boolean>>({})
+const search = ref()
 
 const {
   canCreateDatastreams,
@@ -259,6 +318,12 @@ const updateDatastream = async (updatedDatastream: Datastream) => {
   await fetchMetadata(props.workspace.id)
   onUpdate(updatedDatastream)
 }
+
+// function formatDate(dateString: string) {
+//   return (
+//     new Date(dateString).toUTCString().split(' ').slice(1, 5).join(' ') + ' UTC'
+//   )
+// }
 
 const onCreated = async () => {
   await fetchMetadata(props.workspace.id)
@@ -280,13 +345,47 @@ const { sensors, units, observedProperties, processingLevels, fetchMetadata } =
 const visibleDatastreams = computed(() => {
   return items.value
     .filter((d) => !d.isPrivate || canViewDatastreams.value)
-    .map((d) => ({
-      ...d,
-      chartOpen: false,
-      OPName: observedProperties.value.find(
-        (op) => op.id === d.observedPropertyId
-      )?.name,
-    }))
+    .map((d) => {
+      const unit = units.value.find((u) => u.id === d.unitId)
+      const sensor = sensors.value.find((s) => s.id === d.sensorId)
+      const op = observedProperties.value.find(
+        (o) => o.id === d.observedPropertyId
+      )
+      const pl = processingLevels.value.find(
+        (p) => p.id === d.processingLevelId
+      )
+
+      const mapped = {
+        ...d,
+        chartOpen: false,
+        OPName: op?.name ?? '',
+        processingLevelCode: pl?.code ?? '',
+        processingLevelName: pl?.definition ?? '',
+        sensorName: sensor?.name ?? '',
+        unitName: unit?.name ?? '',
+        searchText: ',',
+      }
+
+      mapped.searchText = [
+        mapped.OPName,
+        mapped.id,
+        mapped.processingLevelName,
+        mapped.sampledMedium,
+        mapped.sensorName,
+        mapped.noDataValue,
+        mapped.aggregationStatistic,
+        mapped.unitName,
+        mapped.status,
+        mapped.valueCount,
+        mapped.phenomenonBeginTime,
+        mapped.phenomenonEndTime,
+      ]
+        .filter(Boolean)
+        .join(' ')
+        .toLowerCase()
+
+      return mapped
+    })
 })
 
 const onDownload = async (datastreamId: string) => {
@@ -301,22 +400,6 @@ const onDownload = async (datastreamId: string) => {
   } finally {
     downloading[datastreamId] = false
   }
-}
-
-const getMostRecentObsTime = (dataArray: DataArray) => {
-  if (!dataArray.length) return undefined
-  return formatDate(dataArray[dataArray.length - 1][0])
-}
-
-const getMostRecentObsVal = (dataArray: DataArray) => {
-  if (!dataArray.length) return undefined
-  return formatNumber(dataArray[dataArray.length - 1][1])
-}
-
-function formatDate(dateString: string) {
-  return (
-    new Date(dateString).toUTCString().split(' ').slice(1, 5).join(' ') + ' UTC'
-  )
 }
 
 async function toggleDataVisibility(datastream: Datastream) {
@@ -347,32 +430,25 @@ const patchDatastream = async (patchBody: {}) => {
   }
 }
 
-const formatNumber = (value: string | number): string => {
-  if (typeof value === 'number') {
-    const formatter = new Intl.NumberFormat('en-US', {
-      minimumFractionDigits: 0,
-      maximumFractionDigits: 2,
-    })
-    return formatter.format(value)
-  }
-
-  return value?.toString()
-}
-
 const sortBy = [{ key: 'OPName' }]
 const headers = [
   {
-    title: 'DataStream Info',
+    title: 'Datastream information',
     key: 'info',
-    value: 'OPName',
+    value: 'searchText',
     sortable: false,
   },
   {
-    title: 'Observations (Last 72 Hours)',
+    title: 'Time information (UTC)',
+    key: 'time',
+
+    sortable: false,
+  },
+  {
+    title: 'Observations (Last 72 hours)',
     key: 'observations',
     sortable: false,
   },
-  { title: 'Last Observation', key: 'last_observation', sortable: false },
   { title: 'Actions', key: 'actions', sortable: false },
 ]
 
@@ -385,3 +461,9 @@ const loadDatastreams = async () => {
   }
 }
 </script>
+
+<style scoped>
+::v-deep tbody .v-data-table__td {
+  vertical-align: top;
+}
+</style>

--- a/src/components/Datastream/DatastreamTableInfoCard.vue
+++ b/src/components/Datastream/DatastreamTableInfoCard.vue
@@ -12,7 +12,7 @@
       >
     </v-toolbar>
 
-    <DatastreamInformationPanels :datastream="datastream" />
+    <DatastreamInformationPanels :datastream="datastream" :thing="thing" />
 
     <v-card-actions>
       <v-spacer />
@@ -22,13 +22,14 @@
 </template>
 
 <script setup lang="ts">
-import { Datastream } from '@/types'
+import { Datastream, Thing } from '@/types'
 import { ref } from 'vue'
 import { downloadDatastreamCSV } from '@/utils/CSVDownloadUtils'
 import DatastreamInformationPanels from '@/components/Datastream/DatastreamInformationPanels.vue'
 
 defineProps({
   datastream: { type: Object as () => Datastream, required: true },
+  thing: { type: Object as () => Thing, required: true },
 })
 
 const emit = defineEmits(['close'])

--- a/src/components/Datastream/DatastreamTableInfoCard.vue
+++ b/src/components/Datastream/DatastreamTableInfoCard.vue
@@ -15,22 +15,14 @@
     <DatastreamInformationPanels :datastream="datastream" />
 
     <v-card-actions>
-      <v-btn-primary color="blue" variant="text" @click="addToPlot(datastream)"
-        >Add to Current Plot</v-btn-primary
-      >
       <v-spacer />
       <v-btn-cancel @click="$emit('close')">Cancel</v-btn-cancel>
-      <v-btn-primary type="submit" @click="clearAndPlot(datastream)"
-        >Clear and Plot</v-btn-primary
-      >
     </v-card-actions>
   </v-card>
 </template>
 
 <script setup lang="ts">
-import { useDataVisStore } from '@/store/dataVisualization'
 import { Datastream } from '@/types'
-import { storeToRefs } from 'pinia'
 import { ref } from 'vue'
 import { downloadDatastreamCSV } from '@/utils/CSVDownloadUtils'
 import DatastreamInformationPanels from '@/components/Datastream/DatastreamInformationPanels.vue'
@@ -38,8 +30,6 @@ import DatastreamInformationPanels from '@/components/Datastream/DatastreamInfor
 defineProps({
   datastream: { type: Object as () => Datastream, required: true },
 })
-
-const { plottedDatastreams } = storeToRefs(useDataVisStore())
 
 const emit = defineEmits(['close'])
 
@@ -53,19 +43,5 @@ const downloadDatastream = async (id: string) => {
     console.error('Error downloading datastream', error)
   }
   downloading.value = false
-}
-
-const addToPlot = (datastream: Datastream) => {
-  const index = plottedDatastreams.value.findIndex(
-    (ds) => ds.id === datastream.id
-  )
-  if (index === -1) plottedDatastreams.value.push(datastream)
-  emit('close')
-}
-
-const clearAndPlot = (datastream: Datastream) => {
-  emit('close')
-  plottedDatastreams.value = []
-  plottedDatastreams.value.push(datastream)
 }
 </script>

--- a/src/components/VisualizeData/DataVisDatasetsTable.vue
+++ b/src/components/VisualizeData/DataVisDatasetsTable.vue
@@ -85,9 +85,14 @@
     </template>
   </v-data-table-virtual>
 
-  <v-dialog v-model="openInfoCard" width="50rem" v-if="selectedDatastream">
+  <v-dialog
+    v-model="openInfoCard"
+    width="50rem"
+    v-if="selectedDatastream && selectedThing"
+  >
     <DatastreamInformationCard
       :datastream="selectedDatastream"
+      :thing="selectedThing"
       @close="openInfoCard = false"
     />
   </v-dialog>
@@ -95,11 +100,12 @@
 
 <script setup lang="ts">
 import { useDataVisStore } from '@/store/dataVisualization'
-import { Datastream } from '@/types'
+import { Datastream, Thing } from '@/types'
 import { storeToRefs } from 'pinia'
 import { computed, reactive, ref } from 'vue'
 import DatastreamInformationCard from './DatastreamInformationCard.vue'
 import { downloadPlottedDatastreamsCSVs } from '@/utils/CSVDownloadUtils'
+import { thing } from '@/utils/test/fixtures'
 
 const {
   things,
@@ -116,6 +122,7 @@ const showOnlySelected = ref(false)
 const openInfoCard = ref(false)
 const downloading = ref(false)
 const selectedDatastream = ref<Datastream | null>(null)
+const selectedThing = ref<Thing | null>(null)
 
 const copyStateToClipboard = async () => {
   emit('copyState')
@@ -135,6 +142,9 @@ const onRowClick = (event: Event, item: any) => {
   // If the click came from a checkbox, do nothing.
   let targetElement = event.target as HTMLElement
   if (targetElement.id && targetElement.id.startsWith('checkbox-')) return
+
+  const foundThing = things.value.find((t) => t.id === item.item.thingId)
+  if (foundThing) selectedThing.value = foundThing
 
   const selectedDatastreamId = item.item.id
   const foundDatastream = filteredDatastreams.value.find(

--- a/src/components/VisualizeData/DatastreamInformationCard.vue
+++ b/src/components/VisualizeData/DatastreamInformationCard.vue
@@ -12,7 +12,7 @@
       >
     </v-toolbar>
 
-    <DatastreamInformationPanels :datastream="datastream" />
+    <DatastreamInformationPanels :datastream="datastream" :thing="thing" />
 
     <v-card-actions>
       <v-btn-primary color="blue" variant="text" @click="addToPlot(datastream)"
@@ -29,7 +29,7 @@
 
 <script setup lang="ts">
 import { useDataVisStore } from '@/store/dataVisualization'
-import { Datastream } from '@/types'
+import { Datastream, Thing } from '@/types'
 import { storeToRefs } from 'pinia'
 import { ref } from 'vue'
 import { downloadDatastreamCSV } from '@/utils/CSVDownloadUtils'
@@ -37,6 +37,7 @@ import DatastreamInformationPanels from '@/components/Datastream/DatastreamInfor
 
 defineProps({
   datastream: { type: Object as () => Datastream, required: true },
+  thing: { type: Object as () => Thing, required: true },
 })
 
 const { plottedDatastreams } = storeToRefs(useDataVisStore())

--- a/src/pages/SiteDetails.vue
+++ b/src/pages/SiteDetails.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-container v-if="loaded && authorized">
+  <div v-if="loaded && authorized" class="my-4 mx-6">
     <h5 class="text-h5 my-4">{{ thing?.name }}</h5>
 
     <v-row v-if="thing" style="height: 25rem">
@@ -82,7 +82,7 @@
     </v-row>
 
     <DatastreamTable v-if="thing && workspace" :workspace="workspace" />
-  </v-container>
+  </div>
   <v-container v-else-if="loaded && !authorized">
     <h5 class="text-h5 my-4">
       You are not authorized to view this private site.

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,6 @@
+export const formatTime = (time: string) =>
+  new Intl.DateTimeFormat('en-US', {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+    timeZone: 'UTC',
+  }).format(new Date(time))


### PR DESCRIPTION
Resolves hydroserver2/hydroserver#290, hydroserver2/hydroserver#291, hydroserver2/hydroserver#297

Refactored the Site Details page's Datastream Table with more fields, a search bar which will filter by any presented text in the row, and on click will open the General datastream information modal. 

![Screenshot 2025-06-26 at 2 59 38 PM](https://github.com/user-attachments/assets/348ae408-ce17-49bb-82ad-0de2d4ee49c8)

