### PR TITLE
Show more data on sparkline plots

### DIFF
--- a/src/components/Datastream/DatastreamTable.vue
+++ b/src/components/Datastream/DatastreamTable.vue
@@ -478,7 +478,7 @@ const headers = [
     sortable: false,
   },
   {
-    title: 'Observations (Last 72 hours)',
+    title: 'Observations (Last 100 values)',
     key: 'observations',
     sortable: false,
   },

--- a/src/components/Datastream/DatastreamTable.vue
+++ b/src/components/Datastream/DatastreamTable.vue
@@ -478,7 +478,7 @@ const headers = [
     sortable: false,
   },
   {
-    title: 'Observations (Last 100 values)',
+    title: 'Observation information',
     key: 'observations',
     sortable: false,
   },

--- a/src/components/Sparkline.vue
+++ b/src/components/Sparkline.vue
@@ -1,6 +1,6 @@
 <template>
   <v-progress-linear v-if="loading" color="secondary" indeterminate />
-  <div v-else-if="!loading && obs100.length" @click="handleEmit">
+  <div v-else-if="!loading && sparklineObservations.length" @click="handleEmit">
     <div style="width: 300px">
       <v-chart
         :option="chartOption"
@@ -13,9 +13,17 @@
           {{ mostRecentDataValue }} {{ unitName }}
         </span>
       </div>
+      <div style="width: 100%">
+        <span class="text-body-3 font-weight-low opacity-70">
+          Sparkline is showing most recent
+          {{ sparklineObservations.length }} values
+        </span>
+      </div>
     </div>
   </div>
-  <div v-else-if="!obs100.length">No data for this datastream</div>
+  <div v-else-if="!sparklineObservations.length">
+    No data for this datastream
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -25,7 +33,7 @@ import VChart from 'vue-echarts'
 import { use } from 'echarts/core'
 import { CanvasRenderer } from 'echarts/renderers'
 import { LineChart } from 'echarts/charts'
-import { DataArray, Datastream } from '@/types'
+import { DataArray, Datastream, TimeSpacingUnit } from '@/types'
 import { preProcessData, subtractHours } from '@/utils/observationsUtils'
 import { useObservationStore } from '@/store/observations'
 import {
@@ -57,11 +65,11 @@ const handleEmit = () => {
   emit('openChart')
 }
 
-const obs100 = ref<DataArray>([])
+const sparklineObservations = ref<DataArray>([])
 const loading = ref(true)
 
 const processedObs = computed(() =>
-  preProcessData(obs100.value, props.datastream)
+  preProcessData(sparklineObservations.value, props.datastream)
 )
 
 const mostRecentDataValue = computed(() => {
@@ -123,7 +131,7 @@ function isStale(timestamp: string | null | undefined) {
 
 const convertToMilliseconds = (
   amount: number,
-  unit: 'seconds' | 'minutes' | 'hours' | 'days'
+  unit: TimeSpacingUnit
 ): number => {
   switch (unit) {
     case 'seconds':
@@ -137,7 +145,7 @@ const convertToMilliseconds = (
   }
 }
 
-const fetchObsLast100 = async (ds: Datastream) => {
+const fetchSparklineObservations = async (ds: Datastream) => {
   const {
     phenomenonEndTime: endTime,
     intendedTimeSpacing,
@@ -152,7 +160,15 @@ const fetchObsLast100 = async (ds: Datastream) => {
       intendedTimeSpacing,
       intendedTimeSpacingUnit
     )
-    const totalDurationMs = spacingMs * 100
+
+    const observationCount =
+      spacingMs >= 86_400_000
+        ? 30 // daily data should display 30 values
+        : spacingMs >= 3_600_000
+        ? 50 // hourly data should display 50 values
+        : 200 // sub-hourly data should display 200 values
+
+    const totalDurationMs = spacingMs * observationCount
     beginTime = new Date(
       new Date(endTime).getTime() - totalDurationMs
     ).toISOString()
@@ -179,7 +195,8 @@ const formatNumber = (value: string | number): string => {
 }
 
 onMounted(async () => {
-  obs100.value = (await fetchObsLast100(props.datastream)) || []
+  sparklineObservations.value =
+    (await fetchSparklineObservations(props.datastream)) || []
   loading.value = false
 })
 </script>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -144,9 +144,9 @@ export class Datastream {
   phenomenonBeginTime?: string | null
   phenomenonEndTime?: string | null
   intendedTimeSpacing?: number
-  intendedTimeSpacingUnit?: string | null
+  intendedTimeSpacingUnit?: TimeSpacingUnit | null
   timeAggregationInterval: number | null
-  timeAggregationIntervalUnit: string
+  timeAggregationIntervalUnit: TimeSpacingUnit
   dataSourceId?: string | null
   valueCount: number
 


### PR DESCRIPTION
Resolves hydroserver2/hydroserver#302

Compute observation fetch range based on intendedTimeSpacing to show last 100 data points. If intended time spacing isn't defined, default to last 72 hours.

<img width="1195" height="257" alt="Screenshot 2025-07-22 at 10 57 54 AM" src="https://github.com/user-attachments/assets/4c0c9e35-f302-420f-ba40-bad74da3a6d2" />
